### PR TITLE
Fix travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
 sudo: required
 
+jdk:
+    - oraclejdk8
+
 addons:
     firefox: latest
 


### PR DESCRIPTION
There was an issue after Travis was updated that caused all builds to fail due to wrong jdk being used in compilation. This branch contains required fix.